### PR TITLE
Query in-app billing service in a null-safe way

### DIFF
--- a/poolakey/src/main/java/com/phelat/poolakey/BillingConnection.kt
+++ b/poolakey/src/main/java/com/phelat/poolakey/BillingConnection.kt
@@ -49,7 +49,7 @@ internal class BillingConnection(
         Intent(BILLING_SERVICE_ACTION).apply { `package` = BAZAAR_PACKAGE_NAME }
             .takeIf(
                 thisIsTrue = {
-                    context.packageManager.queryIntentServices(it, 0).isNotEmpty()
+                    context.packageManager.queryIntentServices(it, 0).isNullOrEmpty().not()
                 },
                 andIfNot = {
                     callback?.connectionFailed?.invoke(BazaarNotFoundException())


### PR DESCRIPTION
Applying this will fix issue #3. It seems like `queryIntentServices`
returns null instead of an empty list on API 17.