### PR TITLE
Set connectionFailed to Print error log by default.

### DIFF
--- a/poolakey/src/main/java/com/phelat/poolakey/callback/ConnectionCallback.kt
+++ b/poolakey/src/main/java/com/phelat/poolakey/callback/ConnectionCallback.kt
@@ -9,7 +9,7 @@ class ConnectionCallback(private val disconnect: () -> Unit) : Connection {
 
     internal var connectionSucceed: () -> Unit = {}
 
-    internal var connectionFailed: (throwable: Throwable) -> Unit = {}
+    internal var connectionFailed: (throwable: Throwable) -> Unit = Throwable::printStackTrace
 
     internal var disconnected: () -> Unit = {}
 


### PR DESCRIPTION
Desirable behavior is to see error log when something unexpectedly happened.